### PR TITLE
correct maelstro frontend f5 not found

### DIFF
--- a/frontend/nginx-default.conf.template
+++ b/frontend/nginx-default.conf.template
@@ -7,7 +7,7 @@ server {
     location /maelstro {
       alias /app;
       index  index.html;
-      try_files $uri $uri/ /index.html;
+      try_files $uri $uri/ /index.html =404;
       autoindex off;
       expires off;
       add_header Cache-Control "public, max-age=0, s-maxage=0, must-revalidate" always;


### PR DESCRIPTION
when i was doing f5 with the frontend behind a nginx frontend i was getting 404 error

this PR fix this problem