### PR TITLE
erase default config of nginx

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,5 +16,5 @@ FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 ENV CUSTOM_SCRIPTS_DIRECTORY ""
 COPY --from=builder --chown=nginx /app/dist /app
-COPY nginx-default.conf.template /etc/nginx/templates/nginx-default.conf.template
+COPY nginx-default.conf.template /etc/nginx/templates/default.conf.template
 COPY ./docker-entrypoint.sh /


### PR DESCRIPTION
I was getting an error in the logs from nginx at each health check request : 
`maelstro-front-1  | 2025/02/25 13:26:59 [error] 46#46: *12 "/usr/share/nginx/html/maelstro/index.html" is not found (2: No such file or directory), client: 127.0.0.1, server: localhost, request: "GET /maelstro/ HTTP/1.1", host: "localhost:8080"`

it was because there were two config use in the container, with this solution it removes the default one by ours to keep only one