### PR TITLE
feat: add OCI image labels

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,6 +29,16 @@ RUN chown -R appuser:appgroup /app
 
 USER appuser
 
+# OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="Maelstro backend"
+LABEL org.opencontainers.image.description="Maelstro backend module for the geOrchestra SDI"
+LABEL org.opencontainers.image.authors="geOrchestra"
+LABEL org.opencontainers.image.vendor="geOrchestra"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+LABEL org.opencontainers.image.url="https://github.com/georchestra/maelstro"
+LABEL org.opencontainers.image.documentation="https://docs.georchestra.org/"
+LABEL org.opencontainers.image.source="https://github.com/georchestra/maelstro"
+
 CMD ["serve_prod"]
 
 FROM server AS check

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,3 +18,13 @@ ENV CUSTOM_SCRIPTS_DIRECTORY ""
 COPY --from=builder --chown=nginx /app/dist /app
 COPY nginx-default.conf.template /etc/nginx/templates/default.conf.template
 COPY ./docker-entrypoint.sh /
+
+# OCI image labels (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="Maelstro frontend"
+LABEL org.opencontainers.image.description="Maelstro frontend module for the geOrchestra SDI"
+LABEL org.opencontainers.image.authors="geOrchestra"
+LABEL org.opencontainers.image.vendor="geOrchestra"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+LABEL org.opencontainers.image.url="https://github.com/georchestra/maelstro"
+LABEL org.opencontainers.image.documentation="https://docs.georchestra.org/"
+LABEL org.opencontainers.image.source="https://github.com/georchestra/maelstro"


### PR DESCRIPTION
useful for renovate to recognize changelog and source of dockerfile: https://docs.renovatebot.com/key-concepts/changelogs/

also clearly state info such as license, description.

useful also for vulnerability scanners to identify which team owns an image or which license is being used, helping to maintain a better security posture.